### PR TITLE
Nuanced Handling of Stuck Subprocesses

### DIFF
--- a/src/pydiode/gui/common.py
+++ b/src/pydiode/gui/common.py
@@ -121,7 +121,6 @@ def check_subprocesses(
         if stuck_running(returncodes):
             # Request cancellation
             cancelled.set(True)
-            # At the next check, hopefully the processes will have exited
             widget.after(
                 SLEEP,
                 lambda: check_subprocesses(

--- a/src/pydiode/tar.py
+++ b/src/pydiode/tar.py
@@ -51,7 +51,8 @@ def main():
                 )
                 sys.exit(1)
             else:
-                raise e
+                print(str(e), file=sys.stderr)
+                sys.exit(1)
         # If you attempt to write to a directory without write access
         except PermissionError as e:
             print(str(e), file=sys.stderr)


### PR DESCRIPTION
Process exit order is nondeterministic, so sometimes tar appears to exit before pydiode, even when both processes complete normally. We should only display an error if there is actually a problem.

For #17