### PR TITLE
Limit UDP packet size on macOS

### DIFF
--- a/src/pydiode/common.py
+++ b/src/pydiode/common.py
@@ -1,9 +1,14 @@
 import logging
 import struct
+import sys
 
 # How much data will fit in each packet we send?
-# Experimentally, this is the maximum UDP payload I can send on macOS.
-UDP_MAX_BYTES = 9216
+# Experimentally, these are the maximum UDP payloads I can send on macOS:
+# - 1472 for multicast packets
+# - 9216 for non-multicast packets
+# macOS can receive multicast packets of either size.
+# For multicast support, we default to 1472 when running on macOS.
+UDP_MAX_BYTES = 1472 if sys.platform == "darwin" else 9216
 
 # Number of bits in a byte
 BYTE = 8

--- a/src/pydiode/receive.py
+++ b/src/pydiode/receive.py
@@ -28,7 +28,7 @@ class AsyncWriter:
                     self.exit_code.set_result(0)
                 else:
                     logging.warning(
-                        "Receieved data's digest != EOF's digest: "
+                        "Received data's digest != EOF's digest: "
                         f"{received_digest.hex()} != {eof_digest.hex()}"
                     )
                     self.exit_code.set_result(1)

--- a/src/pydiode/send.py
+++ b/src/pydiode/send.py
@@ -149,6 +149,7 @@ class AsyncSleeper:
 
 
 async def _send_eof(chunk_duration, transport, digest):
+    logging.debug(f"EOF's digest: {digest.hex()}")
     sleeper = AsyncSleeper(N_EOF, chunk_duration)
     for seq in range(N_EOF):
         header = PACKET_HEADER.pack(b"K", N_EOF, seq)


### PR DESCRIPTION
macOS cannot send multicast packets larger than 1472 bytes. Also, improved logging.

For #25