### PR TITLE
Encrypt pydiode's payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,38 @@ pip install .
 ```
 **Note:** If local installs are slow, remove large files from the repo (e.g., `build`, `dist`, and `random_data`). When installing, pip makes a copy of everything, so large files slow it down.
 
-To run the GUI, Tk must be installed. For example:
+To run the GUI, Tk must be installed.
 - On macOS:
   - `sudo port install py311-tkinter`
   - `sudo port install tk -x11 +quartz`
 - On Linux: `sudo apt install python3.11-tk`
 
-To automatically decrypt PGP-encrypted files:
+### Secure Configuration
+
+The GUI supports using PGP encryption in two ways. First, to encrypt and decrypt all data sent through the GUI. Second, to automatically decrypt PGP-encrypted files (i.e., files ending in .gpg). To use these features, you must install GnuPG.
 - On macOS: `sudo port install gnupg2`
 - On Linux: `sudo apt install gnupg2`
 
-Finally, ensure the `gpg` command is on your PATH. On macOS, this may require using the `launchctl config user path` command.
+I recommend reading [the EFF's guide to public key encryption](https://ssd.eff.org/module/deep-dive-end-end-encryption-how-do-public-key-encryption-systems-work) to get familiar with the terminology used by PGP.
+
+PGP's security depends on keeping your secret key secure. Since decryption is performed by the receiving computer, it is best to only store your secret key on that computer. Thus, we suggest generating a key pair on the receiver. It is okay to accept the default options, though you should specify your name.
+```
+gpg --full-generate-key
+```
+
+Next, export your public key. The name specified during key generation (e.g., Peter Story) can be used to identify the key (i.e., the name serves as a key identifier).
+```
+gpg --armor --export "Peter Story" > story_public.asc
+```
+
+Then, copy the public key to the sending computer, and import it:
+```
+gpg --import story_public.asc
+```
+
+In the pydiode GUI, add the key's identifier to the "PGP Key ID" field in the "Settings" tab on the sender and receiver. It is easiest to use your name, assuming you specified it during key generation (e.g., Peter Story). If you also want to automatically decrypt files ending in .gpg, check the "Decrypt received files" checkbox.
+
+Finally, ensure the `gpg` command is on your PATH, so the pydiode GUI can invoke it. On macOS, this may require using the `launchctl config user path` command.
 
 ## GUI Usage
 

--- a/src/pydiode/gui/main.py
+++ b/src/pydiode/gui/main.py
@@ -118,6 +118,7 @@ def gui_main():
             send_ip.get(),
             receive_ip.get(),
             port.get(),
+            key_id.get(),
             bitrate.get(),
             tx_btn,
             tx_progress,
@@ -154,6 +155,7 @@ def gui_main():
             target.get(),
             receive_ip.get(),
             port.get(),
+            key_id.get(),
             rx_btn,
             rx_progress,
             rx_cancelled,
@@ -193,7 +195,13 @@ def gui_main():
     port = StringVar()
     ttk.Entry(settings_inner, textvariable=port).grid(column=1, row=2)
     port.set(config["pydiode"].get("port", "1234"))
-    ttk.Label(settings_inner, text="Bitrate:").grid(column=0, row=3, sticky="E")
+    ttk.Label(settings_inner, text="PGP Key ID:").grid(
+        column=0, row=3, sticky="E"
+    )
+    key_id = StringVar()
+    ttk.Entry(settings_inner, textvariable=key_id).grid(column=1, row=3)
+    key_id.set(config["pydiode"].get("key_id", ""))
+    ttk.Label(settings_inner, text="Bitrate:").grid(column=0, row=4, sticky="E")
     bitrate = StringVar()
     ttk.Combobox(
         settings_inner,
@@ -205,8 +213,9 @@ def gui_main():
             "750 Mbit/s",
             "1 Gbit/s",
         ),
+        width=12,
         state="readonly",
-    ).grid(column=1, row=3)
+    ).grid(column=1, row=4, sticky="W")
     bitrate.set(config["pydiode"].get("bitrate", "100 Mbit/s"))
     receive_repeatedly = BooleanVar()
     ttk.Checkbutton(
@@ -215,7 +224,7 @@ def gui_main():
         variable=receive_repeatedly,
         onvalue=True,
         offvalue=False,
-    ).grid(column=0, row=4, columnspan=2, sticky="W")
+    ).grid(column=0, row=5, columnspan=2, sticky="W")
     receive_repeatedly.set(config["pydiode"].get("receive_repeatedly", True))
     decrypt_received = BooleanVar()
     ttk.Checkbutton(
@@ -224,7 +233,7 @@ def gui_main():
         variable=decrypt_received,
         onvalue=True,
         offvalue=False,
-    ).grid(column=0, row=5, columnspan=2, sticky="W")
+    ).grid(column=0, row=6, columnspan=2, sticky="W")
     decrypt_received.set(config["pydiode"].get("decrypt_received", True))
     rx_test_cancelled = BooleanVar(value=False)
     rx_test_btn = ttk.Button(
@@ -238,7 +247,7 @@ def gui_main():
             rx_test_cancelled,
         ),
     )
-    rx_test_btn.grid(column=0, row=6, columnspan=2)
+    rx_test_btn.grid(column=0, row=7, columnspan=2)
     tx_test_cancelled = BooleanVar(value=False)
     ttk.Button(
         settings_inner,
@@ -251,7 +260,7 @@ def gui_main():
             bitrate.get(),
             tx_test_cancelled,
         ),
-    ).grid(column=0, row=7, columnspan=2)
+    ).grid(column=0, row=8, columnspan=2)
 
     # Override the default behavior of the Quit menu, so it doesn't cause the
     # application to exit immediately
@@ -273,6 +282,7 @@ def gui_main():
         "send_ip": send_ip.get(),
         "receive_ip": receive_ip.get(),
         "port": port.get(),
+        "key_id": key_id.get(),
         "bitrate": bitrate.get(),
         "receive_repeatedly": receive_repeatedly.get(),
         "decrypt_received": decrypt_received.get(),


### PR DESCRIPTION
Use gpg to encrypt/decrypt data sent using pydiode.

Again, we should test using several different permutations:
- [ ] Frozen executable on macOS
- [ ] Frozen .deb on Linux
- [ ] `pydiode-gui` command on the command-line

For each permutation, ensure that files can be sent with or without the "PGP Key ID" specified. Also, use Wireshark or tcpdump to verify that the payloads are in fact encrypted.

For #31