### PR TITLE
Resolve Missing Packets at Start of Dual-System Transfers

### DIFF
--- a/src/pydiode/send.py
+++ b/src/pydiode/send.py
@@ -227,9 +227,9 @@ async def send_data(
         allow_broadcast=True,
     )
 
-    # Mitigate early packet loss by sending the first chunk at least 10 times
+    # Mitigate early packet loss by sending the first chunk at least 5 times
     warmup = True
-    warmup_redundancy = max(10, redundancy)
+    warmup_redundancy = max(5, redundancy)
 
     # Send data until a None chunk is encountered, indicating EOF
     while True:

--- a/src/pydiode/send.py
+++ b/src/pydiode/send.py
@@ -227,6 +227,10 @@ async def send_data(
         allow_broadcast=True,
     )
 
+    # Mitigate early packet loss by sending the first chunk at least 10 times
+    warmup = True
+    warmup_redundancy = max(10, redundancy)
+
     # Send data until a None chunk is encountered, indicating EOF
     while True:
         if len(chunks) > 0:
@@ -239,8 +243,13 @@ async def send_data(
             else:
                 sha.update(chunk)
                 await _send_chunk(
-                    chunk, color, redundancy, chunk_duration, transport
+                    chunk,
+                    color,
+                    redundancy if not warmup else warmup_redundancy,
+                    chunk_duration,
+                    transport,
                 )
+                warmup = False
                 # Switch the color
                 color = b"B" if color == b"R" else b"R"
         # Wait for more data


### PR DESCRIPTION
When sending data from one system to another, packet loss occurs at the start of each transfer. However, packet loss occurs in a predictable location, so a solution is to retransmit the first chunk beyond the range of this troublesome location.

For #36. Originally discussed in https://github.com/ClarkuCSCI/diode-tuning/issues/5 and #35.