### PR TITLE
Allow Unlimited Bitrate Transfers in GUI

### DIFF
--- a/src/pydiode/gui/main.py
+++ b/src/pydiode/gui/main.py
@@ -203,17 +203,19 @@ def gui_main():
     key_id.set(config["pydiode"].get("key_id", ""))
     ttk.Label(settings_inner, text="Bitrate:").grid(column=0, row=4, sticky="E")
     bitrate = StringVar()
+    bitrate_values = [
+        "100 Mbit/s",
+        "250 Mbit/s",
+        "500 Mbit/s",
+        "750 Mbit/s",
+        "1 Gbit/s",
+    ]
+    if sys.platform == "linux":
+        bitrate_values.append("Unlimited")
     ttk.Combobox(
         settings_inner,
         textvariable=bitrate,
-        values=(
-            "100 Mbit/s",
-            "250 Mbit/s",
-            "500 Mbit/s",
-            "750 Mbit/s",
-            "1 Gbit/s",
-            "Unlimited",
-        ),
+        values=bitrate_values,
         width=12,
         state="readonly",
     ).grid(column=1, row=4, sticky="W")

--- a/src/pydiode/gui/main.py
+++ b/src/pydiode/gui/main.py
@@ -212,11 +212,12 @@ def gui_main():
             "500 Mbit/s",
             "750 Mbit/s",
             "1 Gbit/s",
+            "Unlimited",
         ),
         width=12,
         state="readonly",
     ).grid(column=1, row=4, sticky="W")
-    bitrate.set(config["pydiode"].get("bitrate", "100 Mbit/s"))
+    bitrate.set(config["pydiode"].get("bitrate", "1 Gbit/s"))
     receive_repeatedly = BooleanVar()
     ttk.Checkbutton(
         settings_inner,

--- a/src/pydiode/gui/send.py
+++ b/src/pydiode/gui/send.py
@@ -12,7 +12,7 @@ BYTE = 8
 REDUNDANCY = 2
 # Extra time needed for transfers, considering more than just bitrate and
 # redundancy. Determined experimentally with a 1 Gbit transfer.
-OVERHEAD = 2 if sys.platform == "darwin" else 1.4
+OVERHEAD = 2 if sys.platform == "darwin" else 1.3
 # Increment progress bars every 25 milliseconds, for smooth animation.
 INCREMENT_INTERVAL = 25
 # Test message

--- a/src/pydiode/gui/send.py
+++ b/src/pydiode/gui/send.py
@@ -98,7 +98,9 @@ def bitrate_str_to_int(bitrate_str):
     """
     suffix_mult = {" Mbit/s": 1_000_000, " Gbit/s": 1_000_000_000}
     for suffix, mult in suffix_mult.items():
-        if bitrate_str.endswith(suffix):
+        if bitrate_str == "Unlimited":
+            return 0
+        elif bitrate_str.endswith(suffix):
             return int(bitrate_str.replace(suffix, "")) * mult
     raise ValueError(f"Unknown bitrate format: {bitrate_str}")
 

--- a/src/pydiode/gui/send.py
+++ b/src/pydiode/gui/send.py
@@ -83,6 +83,8 @@ def get_increment_size(sources_list, progress_bar, bitrate_int):
     for source in sources_list:
         size += os.path.getsize(source)
     # How much time will the transfer take, in milliseconds?
+    # If sending with an unlimited bitrate, approximate as 1 Gbit/sec
+    bitrate_int = bitrate_int if bitrate_int else 1_000_000_000
     est_time = size * BYTE / bitrate_int * REDUNDANCY * OVERHEAD * 1000
     # By how much do we increment each time?
     n_increments = est_time / INCREMENT_INTERVAL

--- a/src/pydiode/gui/send.py
+++ b/src/pydiode/gui/send.py
@@ -12,7 +12,7 @@ BYTE = 8
 REDUNDANCY = 2
 # Extra time needed for transfers, considering more than just bitrate and
 # redundancy. Determined experimentally with a 1 Gbit transfer.
-OVERHEAD = 2
+OVERHEAD = 2 if sys.platform == "darwin" else 1.4
 # Increment progress bars every 25 milliseconds, for smooth animation.
 INCREMENT_INTERVAL = 25
 # Test message

--- a/src/pydiode/gui/send.py
+++ b/src/pydiode/gui/send.py
@@ -12,7 +12,7 @@ BYTE = 8
 REDUNDANCY = 2
 # Extra time needed for transfers, considering more than just bitrate and
 # redundancy. Determined experimentally with a 1 Gbit transfer.
-OVERHEAD = 1.085
+OVERHEAD = 2
 # Increment progress bars every 25 milliseconds, for smooth animation.
 INCREMENT_INTERVAL = 25
 # Test message

--- a/src/pydiode/pydiode.py
+++ b/src/pydiode/pydiode.py
@@ -230,10 +230,21 @@ def main():
             # Receive from the network using the main thread
             with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
                 sock.bind((args.read_ip, args.port))
-                # Use macOS's maximum RCVBUF size, which is larger than its
+                # Aim for macOS's maximum RCVBUF size, which is larger than its
                 # default. Linux's default matches its maximum, and is smaller
                 # than macOS's. On Linux, requesting a larger size is ignored.
-                sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 8388608)
+                # On macOS, reqesting a larger size throws an exception.
+                # On macOS, the limit is higher on Apple Silicon.
+                for b in [7456540, 8388608]:
+                    try:
+                        sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, b)
+                    except OSError:
+                        logging.info(f"Failed to set SO_RCVBUF to {b}")
+                logging.info(
+                    "SO_RCVBUF is "
+                    f"{sock.getsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF)}"
+                    " bytes"
+                )
                 receive(q, packet_details, sock)
             if args.packet_details:
                 write_packet_details(args.packet_details, packet_details)


### PR DESCRIPTION
- Allow unlimited bitrate transfers in the GUI on Linux
- GUI should default to 1 Gbit/sec transfers
- Handle receive buffer config more carefully

For #50